### PR TITLE
Add Leetify aim rating stat

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,14 +10,19 @@ HEADERS = {
     "Authorization": "Bearer 8f9985f3-3cf5-43de-970c-dfe244a57fb0"
 }
 
+HEADERS_LEETIFY= {
+    "Accept": "application/json",
+}
+
 # Logger setup
 LOGGER = PluginUtils.Logger("__faceit_stats__")
 
 DEBUG = False
 
 class FaceItUser:
-    def __init__(self, id: str, nickname: str, country: str, avatar: str, cover_image_url: str, faceit_elo: int, skill_level: int):
+    def __init__(self, id: str, steam_id: str, nickname: str, country: str, avatar: str, cover_image_url: str, faceit_elo: int, skill_level: int):
         self.id = id
+        self.steam_id = steam_id
         self.nickname = nickname
         self.country = country
         self.avatar = avatar
@@ -25,6 +30,7 @@ class FaceItUser:
         self.faceit_elo = faceit_elo
         self.skill_level = skill_level
         self.stats = self.get_user_stats()
+        self.aim_rating = self.get_aim_rating()
 
     class UserStats:
         def __init__(self, matches: int, avg_hs: float, avg_kd: float, adr: float, winrate: float):
@@ -61,6 +67,7 @@ class FaceItUser:
         
         return FaceItUser(
             id=data.get("player_id", ""),
+            steam_id=steamId,
             nickname=data.get("nickname", "Unknown"),
             country=data.get("country", "Unknown"),
             avatar=data.get("avatar", ""),
@@ -90,6 +97,21 @@ class FaceItUser:
             print(f"Failed to fetch FaceIt stats: {e}")
         
         return None
+    
+    def get_aim_rating(self):
+        """Fetches aim rating from Leetify API."""
+        url = f"https://api.leetify.com/api/profile/{self.steam_id}"
+        
+        try:
+            response = requests.get(url, headers=HEADERS_LEETIFY)
+            response.raise_for_status()
+            data = response.json()
+            aim_rating = data.get("recentGameRatings", {}).get("aim", 0.0)
+            return round(aim_rating)
+        except requests.RequestException as e:
+            print(f"Failed to fetch aim rating: {e}")
+            return None
+
 
     def __repr__(self):
         return (

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,6 @@ class FaceItUser:
         self.faceit_elo = faceit_elo
         self.skill_level = skill_level
         self.stats = self.get_user_stats()
-        self.aim_rating = self.get_aim_rating()
 
     class UserStats:
         def __init__(self, matches: int, avg_hs: float, avg_kd: float, adr: float, winrate: float):

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,9 +20,8 @@ LOGGER = PluginUtils.Logger("__faceit_stats__")
 DEBUG = False
 
 class FaceItUser:
-    def __init__(self, id: str, steam_id: str, nickname: str, country: str, avatar: str, cover_image_url: str, faceit_elo: int, skill_level: int):
+    def __init__(self, id: str, nickname: str, country: str, avatar: str, cover_image_url: str, faceit_elo: int, skill_level: int):
         self.id = id
-        self.steam_id = steam_id
         self.nickname = nickname
         self.country = country
         self.avatar = avatar
@@ -67,7 +66,6 @@ class FaceItUser:
         
         return FaceItUser(
             id=data.get("player_id", ""),
-            steam_id=steamId,
             nickname=data.get("nickname", "Unknown"),
             country=data.get("country", "Unknown"),
             avatar=data.get("avatar", ""),
@@ -98,21 +96,6 @@ class FaceItUser:
         
         return None
     
-    def get_aim_rating(self):
-        """Fetches aim rating from Leetify API."""
-        url = f"https://api.leetify.com/api/profile/{self.steam_id}"
-        
-        try:
-            response = requests.get(url, headers=HEADERS_LEETIFY)
-            response.raise_for_status()
-            data = response.json()
-            aim_rating = data.get("recentGameRatings", {}).get("aim", 0.0)
-            return round(aim_rating)
-        except requests.RequestException as e:
-            print(f"Failed to fetch aim rating: {e}")
-            return None
-
-
     def __repr__(self):
         return (
             f"FaceItUser(id={self.id}, nickname={self.nickname}, country={self.country}, "
@@ -126,6 +109,20 @@ def get_user_by_steamId(steamId):
         user.stats = user.stats.__dict__ if user.stats else None
         return json.dumps(user.__dict__)
     return None
+
+def get_aim_rating(steamId):
+    """Fetches aim rating from Leetify API."""
+    url = f"https://api.leetify.com/api/profile/{steamId}"
+        
+    try:
+        response = requests.get(url, headers=HEADERS_LEETIFY)
+        response.raise_for_status()
+        data = response.json()
+        aim_rating = data.get("recentGameRatings", {}).get("aim", 0.0)
+        return round(aim_rating)
+    except requests.RequestException as e:
+        print(f"Failed to fetch aim rating: {e}")
+        return None
 
 def GetPluginDir():
     return os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))

--- a/webkit/index.tsx
+++ b/webkit/index.tsx
@@ -104,6 +104,11 @@ export default async function WebkitMain() {
                             <li class="tick">CS2 last 2 weeks hours: <a target="_blank" class="nolink" href="https://steamcommunity.com/profiles/${steamID64}/games/?tab=recent" rel="noopener"><span class="account-steaminfo-row-value">${csRecentHours}</span></a></li>
                         </ul>
                     </div>
+                    <div class="account-steaminfo-row">
+                        <ul style="margin: 0; padding: 0;">
+                            <li class="tick">Leetify aim rating: <a target="_blank" class="nolink" href="https://leetify.com/app/profile/${steamID64}" rel="noopener"><span class="account-steaminfo-row-value">${faceItUserJSON?.aim_rating ?? 'N/A'}</span></a></li>
+                        </ul>
+                    </div>
                 </div>
                 <div class="account-faceitinfo-container">
                     <div class="account-faceit-cover" style="background-image: url(${faceItUserJSON?.cover_image_url ?? ''})"></div>

--- a/webkit/index.tsx
+++ b/webkit/index.tsx
@@ -71,6 +71,8 @@ export default async function WebkitMain() {
             const faceItUser = await Millennium.callServerMethod("get_user_by_steamId", {steamId: steamID64})
             const faceItUserJSON = JSON.parse(faceItUser);
 
+            const leetifyAimRating = await Millennium.callServerMethod("get_aim_rating", {steamId: steamID64})
+
             const statsHTML = document.createElement("div");
             statsHTML.innerHTML = `
             <div class="account-row">
@@ -106,7 +108,7 @@ export default async function WebkitMain() {
                     </div>
                     <div class="account-steaminfo-row">
                         <ul style="margin: 0; padding: 0;">
-                            <li class="tick">Leetify aim rating: <a target="_blank" class="nolink" href="https://leetify.com/app/profile/${steamID64}" rel="noopener"><span class="account-steaminfo-row-value">${faceItUserJSON?.aim_rating ?? 'N/A'}</span></a></li>
+                            <li class="tick">Leetify aim rating: <a target="_blank" class="nolink" href="https://leetify.com/app/profile/${steamID64}" rel="noopener"><span class="account-steaminfo-row-value">${leetifyAimRating != null ? `${leetifyAimRating}%` : 'N/A'}</span></a></li>
                         </ul>
                     </div>
                 </div>

--- a/webkit/index.tsx
+++ b/webkit/index.tsx
@@ -108,7 +108,7 @@ export default async function WebkitMain() {
                     </div>
                     <div class="account-steaminfo-row">
                         <ul style="margin: 0; padding: 0;">
-                            <li class="tick">Leetify aim rating: <a target="_blank" class="nolink" href="https://leetify.com/app/profile/${steamID64}" rel="noopener"><span class="account-steaminfo-row-value">${leetifyAimRating != null ? `${leetifyAimRating}%` : 'N/A'}</span></a></li>
+                            <li class="tick">Leetify aim rating: <a target="_blank" class="nolink" href="https://leetify.com/app/profile/${steamID64}" rel="noopener"><span class="account-steaminfo-row-value">${leetifyAimRating != 0 ? `${leetifyAimRating}%` : 'N/A'}</span></a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Hi,
I figured that this plugin would be used as an easier way to figure out if someone is a cheater in a counter strike game (without having to go to multiple different websites) and the aim rating leetify provides is a fairly good indicator for that.

I added a function to the backend to get the aim rating from the leetify api and then display it below the player's last 2 week hours
![image](https://github.com/user-attachments/assets/4755246d-d7d7-4770-899f-2d9203bcca59)